### PR TITLE
GameStateの要素に画像保持領域を追加、画像生成後にredisへ保存

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -890,6 +890,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/@radix-ui/react-aspect-ratio": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.1.tgz",

--- a/src/types/GameState.ts
+++ b/src/types/GameState.ts
@@ -9,7 +9,6 @@ export interface GameState {
   round: number;
   users: UserStatus[];
   isAllUsersReady: boolean;
-
   // ユーザーごとの画像リスト
   images :{
     [userId:string] :string[]

--- a/src/types/GameState.ts
+++ b/src/types/GameState.ts
@@ -9,6 +9,11 @@ export interface GameState {
   round: number;
   users: UserStatus[];
   isAllUsersReady: boolean;
+
+  // ユーザーごとの画像リスト
+  images :{
+    [userId:string] :string[]
+  }
 }
 
 export interface GameStateRequest {

--- a/src/types/GenerateImage.ts
+++ b/src/types/GenerateImage.ts
@@ -1,7 +1,11 @@
+import { GameState } from './GameState';
+
 export interface GenerateImageRequest {
   prompt: string;
   n: number; // 生成する画像の数
   size: string; // 例: "256x256"
+  userId: string;//ユーザーID
+  gameState: GameState;//ゲームステート
 }
 
 export interface GenerateImageResponse {

--- a/src/types/GenerateImage.ts
+++ b/src/types/GenerateImage.ts
@@ -9,7 +9,7 @@ export interface GenerateImageRequest {
 }
 
 export interface GenerateImageResponse {
-  url: string;
+  url: string | Error;
 }
 
 export interface GeneratedImageProps {

--- a/src/utils/client/apiClient.ts
+++ b/src/utils/client/apiClient.ts
@@ -3,7 +3,7 @@
 response.dataからの展開はこの関数内で行い、展開後のデータをクライアントサイドへ返している。
 */
 
-import type { GenerateImageResponse } from '@/types/GenerateImage'
+import type { GenerateImageRequest, GenerateImageResponse } from '@/types/GenerateImage'
 import { TranslatePromptResponse } from '@/types/TranslatePrompt'
 import type { GameState, GameStateRequest } from '@/types/GameState'
 
@@ -40,12 +40,12 @@ async function handleFetchApi<T> (
 
 // プロンプトから画像生成 -------------------------------------------------
 export async function fetchGenerateImage (
-  prompt: string
+  request: GenerateImageRequest
 ): Promise<GenerateImageResponse | null> {
   return await handleFetchApi<GenerateImageResponse>('/api/generate-image', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ prompt })
+    body: JSON.stringify(request)
   })
 }
 

--- a/src/utils/server/api/generateImage.ts
+++ b/src/utils/server/api/generateImage.ts
@@ -1,22 +1,43 @@
 import OpenAI from 'openai';
+import { GameState } from '@/types/GameState';
+import { GenerateImageRequest } from '@/types/GenerateImage';
+import { kvSet } from '@/utils/server/vercelKVHandler';
+
+
 
 // OpenAI APIを用いて画像を生成する関数
-export async function generateImage(prompt: string) {
+export async function generateImage(request: GenerateImageRequest): Promise<{ url: string  } | Error> {
+  //OpenAIのAPIキーを環境変数から設定して、OpenAIクライアントを生成
   const openai = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
   });
 
+  // リクエストから必要なデータを取得
+  const { prompt, userId, gameState } = request;
+
   try {
+    // OpenAI APIを用いて画像を生成
     const response = await openai.images.generate({
       prompt,
-      n: 1,
+      n:1,
       size: '256x256',
     });
 
+
+    // 生成した画像のURLを取得
+    const imageUrl:string = response.data[0]?.url ?? '';
+
+    // 生成した画像のURLをGameStateに追加
+    gameState.images[userId].push(imageUrl);
+
+    // GameStateを更新
+    await kvSet(gameState.gameId, gameState);
+
+
     return {
-      url: response.data[0]?.url ?? '',
+      url: imageUrl,
     };
   } catch (error) {
-    return error;
-  }
+    return error as Error;
+  } 
 }


### PR DESCRIPTION
変更点

・interfaceのGameStateに要素としてimagesを追加。（ユーザーIDをキーで生成画像URLのリストを保持）

・interface GenerateImageRequestにuserIdとgameStateを要素として追加
　
・openApiを叩くgenerateImageの引数にGenerateImageRequestにして、生成画像をgameStateに格納、redisに保存。

